### PR TITLE
Updating Ember.Handlebars.SafeString

### DIFF
--- a/app/helpers/dropdown-option.js
+++ b/app/helpers/dropdown-option.js
@@ -17,5 +17,5 @@ export default Ember.Helper.helper(function(params, hash) {
     value = data;
     display = data;
   }
-  return new Em.Handlebars.SafeString(`<option value="${value}">${display}</option>`);
+  return new Em.String.htmlSafe(`<option value="${value}">${display}</option>`);
 });


### PR DESCRIPTION
Ember.Handlebars.SafeString deprecated in favor of Ember.String.htmlSafe
